### PR TITLE
Refine examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # SimpleNamedPipe
 SimpleNamedPipe is a lightweight C++ library for creating and managing asynchronous named pipe servers on Windows.
 
-
 ## Полезные ссылки
 
 - [Нamed Pipe Server using Overlapped I/O](https://learn.microsoft.com/ru-ru/windows/win32/ipc/named-pipe-server-using-overlapped-i-o)
 - [Winsock2 Advanced Named Pipe](https://www.winsocketdotnetworkprogramming.com/winsock2programming/winsock2advancednamedpipe15a.html)
 - [Основы разработки программ для операционных систем семейств Windows и Linux](https://repo.ssau.ru/bitstream/Uchebnye-izdaniya/Operacionnye-sistemy-Osnovy-razrabotki-programm-dlya-operacionnyh-sistem-semeistv-Windows-i-Linux-109472/1/978-5-7883-2035-9_%202024.pdf)
+
+## Примеры
+
+Исходники примеров расположены в каталоге `examples`.
+- `callback_example.cpp` демонстрирует работу сервера с отдельными коллбэками (`on_connected`, `on_message` и т.д.).
+- `universal_event_example.cpp` показывает аналогичную логику, но используя единый обработчик `on_event`.

--- a/examples/callback_example.cpp
+++ b/examples/callback_example.cpp
@@ -1,0 +1,60 @@
+#include "SimpleNamedPipe/NamedPipeServer.hpp"
+#include <iostream>
+#include <chrono>
+
+using namespace SimpleNamedPipe;
+
+int main() {
+    // Server configuration
+    ServerConfig config;
+    config.pipe_name = "ExamplePipe";
+    config.buffer_size = 1024;
+    config.timeout = 5000;
+
+    NamedPipeServer server(config);
+
+    // Counter for messages from each client
+    std::array<int, 256> message_counters{};
+
+    // Callbacks
+    server.on_connected = [](int client_id) {
+        std::cout << "client(" << client_id << ") connected." << std::endl;
+    };
+
+    server.on_disconnected = [](int client_id, const std::error_code& ec) {
+        std::cout << "client(" << client_id << ") disconnected: " << ec.message() << std::endl;
+    };
+
+    server.on_message = [&server, &message_counters](int client_id, const std::string& message) {
+        std::cout << "client(" << client_id << ") received: " << message << std::endl;
+
+        // Echo the message back
+        server.send_to(client_id, "Echo: " + message);
+        message_counters[static_cast<size_t>(client_id)]++;
+
+        // Disconnect after 10 messages
+        if (message_counters[static_cast<size_t>(client_id)] >= 10) {
+            server.close(client_id);
+        }
+    };
+
+    server.on_start = [](const ServerConfig& cfg) {
+        std::cout << "Server started on pipe: " << cfg.pipe_name << std::endl;
+    };
+
+    server.on_stop = [](const ServerConfig&) {
+        std::cout << "Server stopped." << std::endl;
+    };
+
+    server.on_error = [](const std::error_code& error) {
+        std::cerr << "Error: " << error.message() << std::endl;
+    };
+
+    std::cout << "Press Enter to stop the server..." << std::endl;
+    server.start();
+
+    std::cin.get();
+
+    server.stop();
+    return 0;
+}

--- a/examples/universal_event_example.cpp
+++ b/examples/universal_event_example.cpp
@@ -1,0 +1,50 @@
+#include "SimpleNamedPipe/NamedPipeServer.hpp"
+#include <iostream>
+
+using namespace SimpleNamedPipe;
+
+int main() {
+    ServerConfig config;
+    config.pipe_name = "ExamplePipe";
+    config.buffer_size = 1024;
+    config.timeout = 5000;
+
+    NamedPipeServer server(config);
+    std::array<int, 256> message_counters{};
+
+    server.on_event = [&server, &message_counters](const ServerEvent& ev) {
+        switch (ev.type) {
+        case ServerEventType::ServerStarted:
+            std::cout << "Server started on pipe: " << server.get_config().pipe_name << std::endl;
+            break;
+        case ServerEventType::ServerStopped:
+            std::cout << "Server stopped." << std::endl;
+            break;
+        case ServerEventType::ClientConnected:
+            std::cout << "client(" << ev.client_id << ") connected." << std::endl;
+            break;
+        case ServerEventType::ClientDisconnected:
+            std::cout << "client(" << ev.client_id << ") disconnected: " << ev.error.message() << std::endl;
+            break;
+        case ServerEventType::MessageReceived:
+            std::cout << "client(" << ev.client_id << ") received: " << ev.message << std::endl;
+            if (ev.connection) {
+                ev.connection->send("Echo: " + ev.message);
+                message_counters[static_cast<size_t>(ev.client_id)]++;
+                if (message_counters[static_cast<size_t>(ev.client_id)] >= 10) {
+                    ev.connection->close();
+                }
+            }
+            break;
+        case ServerEventType::ErrorOccurred:
+            std::cerr << "Error: " << ev.error.message() << std::endl;
+            break;
+        }
+    };
+
+    std::cout << "Press Enter to stop the server..." << std::endl;
+    server.start();
+    std::cin.get();
+    server.stop();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- adjust message log text in callback example
- use connection object in universal event example
- drop redundant includes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a39440b0832c8e9136c9cc56c912