### PR TITLE
Fix write offset update in NamedPipeServer

### DIFF
--- a/include/SimpleNamedPipe/NamedPipeServer/NamedPipeServer.ipp
+++ b/include/SimpleNamedPipe/NamedPipeServer/NamedPipeServer.ipp
@@ -402,7 +402,7 @@ namespace SimpleNamedPipe {
         size_t bytes_to_copy = std::min(buffer_size, cmd.message.size() - msg_offset);
         auto& buffer = m_write_buffers[index];
         buffer.assign(cmd.message.begin() + msg_offset, cmd.message.begin() + msg_offset + bytes_to_copy);
-        cmd.offset = bytes_to_copy;
+        cmd.offset += bytes_to_copy;
 
         OVERLAPPED* ov = &m_write_overlapped[index];
         memset(ov, 0, sizeof(OVERLAPPED));


### PR DESCRIPTION
## Summary
- fix update of write command offset in `post_next_write`

## Testing
- `apt-get update`
- `apt-get install -y tree`

------
https://chatgpt.com/codex/tasks/task_e_6854ab46c7d8832c92c9dbf173ea6367