### PR TITLE
fix(docs): correct \file comment

### DIFF
--- a/include/SimpleNamedPipe/NamedPipeServer/ServerConfig.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer/ServerConfig.hpp
@@ -2,7 +2,7 @@
 #ifndef _SIMPLE_NAMED_PIPE_SERVER_CONFIG_HPP_INCLUDED
 #define _SIMPLE_NAMED_PIPE_SERVER_CONFIG_HPP_INCLUDED
 
-/// \file Config.hpp
+/// \file ServerConfig.hpp
 /// \brief Конфигурация сервера именованных каналов.
 
 #include <string>


### PR DESCRIPTION
## Summary
- fix incorrect filename in the doc comment of `ServerConfig.hpp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a8392184832cbd133cbd914233e0