### PR TITLE
Add and translate Doxygen comments

### DIFF
--- a/include/SimpleNamedPipe/NamedPipeServer.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer.hpp
@@ -27,7 +27,7 @@
 namespace SimpleNamedPipe {
 
     /// \class NamedPipeServer
-    /// \brief
+    /// \brief Asynchronous named pipe server implementation.
     class NamedPipeServer final : public IConnection {
     public:
 
@@ -51,41 +51,41 @@ namespace SimpleNamedPipe {
 
         // API
 
-        /// \brief
-        /// \param handler
+        /// \brief Sets a custom event handler instance.
+        /// \param handler Shared pointer to the handler.
         void set_event_handler(std::shared_ptr<ServerEventHandler> handler);
 
-        /// \brief
-        /// \return
+        /// \brief Returns the currently assigned event handler.
+        /// \return Shared pointer to the handler or nullptr.
         std::shared_ptr<ServerEventHandler> get_event_handler() const;
 
-        /// \brief
-        /// \param config
+        /// \brief Applies a new server configuration.
+        /// \param config Configuration to use.
         void set_config(const ServerConfig& config);
 
         /// \brief Retrieves the current server configuration.
-        /// \return
+        /// \return Copy of the configuration object.
         const ServerConfig get_config() const;
 
         /// \brief Starts the server.
         /// \param run_async Whether to run the server in a background thread.
         void start(bool run_async = true);
 
-        /// \brief Stops the server.
+        /// \brief Stops the server and waits for the thread to finish.
         void stop();
 
         /// \brief Checks whether the server is currently running.
         bool is_running() const;
 
-        /// \brief
-        /// \param client_id
-        /// \param message
-        /// \param on_done
+        /// \brief Sends a message to a connected client.
+        /// \param client_id ID of the client.
+        /// \param message Message to send.
+        /// \param on_done Optional callback invoked when send completes.
         void send_to(int client_id, const std::string& message, DoneCallback on_done = nullptr) override;
 
-        /// \brief
-        /// \param client_id
-        /// \param on_done
+        /// \brief Closes the connection with a client.
+        /// \param client_id ID of the client.
+        /// \param on_done Optional callback invoked when the client is closed.
         void close(int client_id, DoneCallback on_done = nullptr) override;
 
         /// \brief Checks whether a client is currently connected.

--- a/include/SimpleNamedPipe/NamedPipeServer/Connection.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer/Connection.hpp
@@ -10,13 +10,21 @@
 
 namespace SimpleNamedPipe {
 
+    /// \class Connection
+    /// \brief Lightweight wrapper for client-side operations.
     class Connection {
     public:
         using DoneCallback = std::function<void(const std::error_code&)>;
 
+        /// \brief Construct connection helper for a client.
+        /// \param client_id Identifier of the client.
+        /// \param impl Pointer to the server implementation.
         Connection(int client_id, IConnection* impl)
             : m_client_id(client_id), m_impl(impl), m_alive(true) {}
 
+        /// \brief Send message through this connection.
+        /// \param message UTF-8 encoded string to send.
+        /// \param on_done Optional completion callback.
         void send(const std::string& message, DoneCallback on_done = nullptr) const {
             std::unique_lock<std::mutex> lock(m_mutex);
             if (is_alive()) {
@@ -27,6 +35,8 @@ namespace SimpleNamedPipe {
             }
         }
 
+        /// \brief Close this connection.
+        /// \param on_done Optional completion callback.
         void close(DoneCallback on_done = nullptr) const {
             std::unique_lock<std::mutex> lock(m_mutex);
             if (is_alive()) {
@@ -37,21 +47,25 @@ namespace SimpleNamedPipe {
             }
         }
 
+        /// \brief Check whether the underlying client is connected.
         bool is_connected() const {
             std::lock_guard<std::mutex> lock(m_mutex);
             if (!is_alive()) return false;
             return m_impl && m_impl->is_connected(m_client_id);
         }
 
+        /// \brief Retrieve the associated client identifier.
         int client_id() const {
             return m_client_id;
         }
 
+        /// \brief Mark this connection as no longer valid.
         void invalidate() {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_alive.store(false, std::memory_order_release);
         }
 
+        /// \brief Determine if this wrapper is still active.
         bool is_alive() const {
             return m_alive.load(std::memory_order_acquire);
         }

--- a/include/SimpleNamedPipe/NamedPipeServer/IConnection.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer/IConnection.hpp
@@ -12,15 +12,15 @@ namespace SimpleNamedPipe {
 
         virtual ~IConnection() = default;
 
-        /// \brief
-        /// \param client_id
-        /// \param message
-        /// \param on_done
+        /// \brief Send a message to a specific client.
+        /// \param client_id Identifier of the client.
+        /// \param message   UTF-8 message to send.
+        /// \param on_done   Optional completion callback.
         virtual void send_to(int client_id, const std::string& message, DoneCallback on_done) = 0;
 
-        /// \brief
-        /// \param client_id
-        /// \param on_done
+        /// \brief Close connection with the given client.
+        /// \param client_id Identifier of the client.
+        /// \param on_done   Optional completion callback.
         virtual void close(int client_id, DoneCallback on_done) = 0;
 
         /// \brief Checks whether a client is currently connected.

--- a/include/SimpleNamedPipe/NamedPipeServer/ServerConfig.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer/ServerConfig.hpp
@@ -3,33 +3,33 @@
 #define _SIMPLE_NAMED_PIPE_SERVER_CONFIG_HPP_INCLUDED
 
 /// \file ServerConfig.hpp
-/// \brief Конфигурация сервера именованных каналов.
+/// \brief Configuration for the named pipe server.
 
 #include <string>
 
 namespace SimpleNamedPipe {
 
     /// \struct WriteQueueLimits
-    /// \brief Ограничения на очередь записи, включая лимиты на количество сообщений, размер сообщений и общий объём.
+    /// \brief Limits for the write queue, including message count and size restrictions.
     struct WriteQueueLimits {
-        size_t max_pending_writes_per_client = 1000;           ///< Макс. сообщений в очереди на клиента
-        size_t max_message_size = 64 * 1024;                   ///< Макс. размер одного сообщения (64 KB)
-        size_t max_total_queue_memory = 100 * 1024 * 1024;     ///< Макс. общий объём сообщений (100 MB)
+        size_t max_pending_writes_per_client = 1000;           ///< Max messages queued per client
+        size_t max_message_size = 64 * 1024;                   ///< Max single message size (64 KB)
+        size_t max_total_queue_memory = 100 * 1024 * 1024;     ///< Max total queued size (100 MB)
     };
 
-    /// \class Config
-    /// \brief Конфигурация сервера именованных каналов.
+    /// \class ServerConfig
+    /// \brief Named pipe server configuration.
     class ServerConfig {
     public:
-        std::string      pipe_name;    ///< Имя именованного канала
-        WriteQueueLimits write_limits; ///< Лимиты очереди записи
-        size_t           buffer_size;  ///< Размер буфера для чтения и записи
-        size_t           timeout;      ///< Время ожидания в миллисекундах
+        std::string      pipe_name;    ///< Named pipe name
+        WriteQueueLimits write_limits; ///< Limits for the write queue
+        size_t           buffer_size;  ///< Size of I/O buffers
+        size_t           timeout;      ///< Timeout in milliseconds
 
-        /// \brief Конструктор с параметрами.
-        /// \param pipe_name Имя канала.
-        /// \param buffer_size Размер буфера.
-        /// \param timeout Таймаут в мс.
+        /// \brief Construct with optional parameters.
+        /// \param pipe_name Name of the pipe.
+        /// \param buffer_size Buffer size in bytes.
+        /// \param timeout Wait timeout in ms.
         ServerConfig(const std::string& pipe_name = "server",
                size_t buffer_size = 65536,
                size_t timeout = 50)

--- a/include/SimpleNamedPipe/NamedPipeServer/ServerEventHandler.hpp
+++ b/include/SimpleNamedPipe/NamedPipeServer/ServerEventHandler.hpp
@@ -3,12 +3,12 @@
 #define _SIMPLE_NAMED_PIPE_SERVER_EVENT_HANDLER_HPP_INCLUDED
 
 /// \file ServerEventHandler.hpp
-/// \brief
+/// \brief Base interface for handling server events.
 
 namespace SimpleNamedPipe {
 
     /// \struct ServerEventHandler
-    /// \brief Класс для удобной работы с событиями
+    /// \brief Helper interface for reacting to server events.
     class ServerEventHandler {
     public:
         virtual ~ServerEventHandler() = default;


### PR DESCRIPTION
## Summary
- add missing Doxygen descriptions for public API
- translate Russian comments in headers and implementation
- document helper classes with brief explanations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854e06551f8832cb02f5447d919b9b6