### PR TITLE
fix: mark NamedPipeServer inline definitions

### DIFF
--- a/.github/workflows/odr-test.yml
+++ b/.github/workflows/odr-test.yml
@@ -1,0 +1,15 @@
+name: ODR Regression Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  odr-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Run ODR regression build
+        run: tests/odr/run_odr_test.sh

--- a/include/SimpleNamedPipe/NamedPipeServer/NamedPipeServer.ipp
+++ b/include/SimpleNamedPipe/NamedPipeServer/NamedPipeServer.ipp
@@ -8,29 +8,29 @@
 
 namespace SimpleNamedPipe {
 
-    NamedPipeServer::NamedPipeServer() {
+    inline NamedPipeServer::NamedPipeServer() {
         for (size_t i = 0; i < MAX_CLIENTS; ++i) {
             m_pipes[i] = INVALID_HANDLE_VALUE;
         }
     };
 
-    NamedPipeServer::NamedPipeServer(const ServerConfig& config) {
+    inline NamedPipeServer::NamedPipeServer(const ServerConfig& config) {
         set_config(config);
     };
 
-    NamedPipeServer::~NamedPipeServer() {
+    inline NamedPipeServer::~NamedPipeServer() {
         stop();
     }
 
-    void NamedPipeServer::set_event_handler(std::shared_ptr<ServerEventHandler> handler) {
+    inline void NamedPipeServer::set_event_handler(std::shared_ptr<ServerEventHandler> handler) {
         m_event_handler = handler;
     }
 
-    std::shared_ptr<ServerEventHandler> NamedPipeServer::get_event_handler() const {
+    inline std::shared_ptr<ServerEventHandler> NamedPipeServer::get_event_handler() const {
         return m_event_handler;
     }
 
-    void NamedPipeServer::set_config(const ServerConfig& config) {
+    inline void NamedPipeServer::set_config(const ServerConfig& config) {
         std::unique_lock<std::mutex> lock(m_config_mutex);
         m_config = config;
         m_is_config_updated = true;
@@ -46,12 +46,12 @@ namespace SimpleNamedPipe {
         }
     }
 
-    const ServerConfig NamedPipeServer::get_config() const {
+    inline const ServerConfig NamedPipeServer::get_config() const {
         std::lock_guard<std::mutex> lock(m_config_mutex);
         return m_config;
     }
 
-    void NamedPipeServer::start(bool run_async) {
+    inline void NamedPipeServer::start(bool run_async) {
         std::lock_guard<std::mutex> lock(m_mutex);
         if (m_server_thread.joinable()) {
             m_is_stop_server = true;
@@ -70,7 +70,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::stop() {
+    inline void NamedPipeServer::stop() {
         std::lock_guard<std::mutex> lock(m_mutex);
         if (m_is_stop_server) return;
         m_is_stop_server = true;
@@ -85,11 +85,11 @@ namespace SimpleNamedPipe {
         }
     }
 
-    bool NamedPipeServer::is_running() const {
+    inline bool NamedPipeServer::is_running() const {
         return m_is_running.load(std::memory_order_acquire);
     }
 
-    void NamedPipeServer::send_to(int client_id, const std::string& message, DoneCallback on_done) {
+    inline void NamedPipeServer::send_to(int client_id, const std::string& message, DoneCallback on_done) {
         HANDLE completion_port = m_completion_port.load(std::memory_order_acquire);
 
         if (!m_is_running.load(std::memory_order_acquire) || !completion_port) {
@@ -111,7 +111,7 @@ namespace SimpleNamedPipe {
         PostQueuedCompletionStatus(completion_port, 0, CMD_TYPE_SEND | (index & CMD_INDEX_MASK), nullptr);
     }
 
-    void NamedPipeServer::close(int client_id, DoneCallback on_done) {
+    inline void NamedPipeServer::close(int client_id, DoneCallback on_done) {
         HANDLE completion_port = m_completion_port.load(std::memory_order_acquire);
 
         if (!m_is_running.load(std::memory_order_acquire) || !completion_port) {
@@ -128,19 +128,19 @@ namespace SimpleNamedPipe {
         PostQueuedCompletionStatus(completion_port, 0, CMD_TYPE_CLOSE | (index & CMD_INDEX_MASK), nullptr);
     }
 
-    bool NamedPipeServer::is_connected(int client_id) const {
+    inline bool NamedPipeServer::is_connected(int client_id) const {
         size_t index = check_client_id(client_id);
         return m_is_connected[index].load(std::memory_order_acquire);
     }
 
-    size_t NamedPipeServer::check_client_id(int client_id) const {
+    inline size_t NamedPipeServer::check_client_id(int client_id) const {
         if (client_id < 0 || static_cast<size_t>(client_id) >= MAX_CLIENTS) {
             throw std::out_of_range("client_id is out of range");
         }
         return static_cast<size_t>(client_id);
     }
 
-    bool NamedPipeServer::check_write_limits(int client_id, const std::string& message, std::error_code& ec) {
+    inline bool NamedPipeServer::check_write_limits(int client_id, const std::string& message, std::error_code& ec) {
         if (message.size() > m_write_limits.max_message_size) {
             ec = make_error_code(NamedPipeErrc::MessageTooLarge);
             return false;
@@ -157,7 +157,7 @@ namespace SimpleNamedPipe {
         return true;
     }
 
-    void NamedPipeServer::init(const ServerConfig& config) {
+    inline void NamedPipeServer::init(const ServerConfig& config) {
         m_write_limits = config.write_limits;
 
         HANDLE completion_port = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 0);
@@ -177,7 +177,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::create_pipe(size_t index, HANDLE completion_port, const ServerConfig& config) {
+    inline void NamedPipeServer::create_pipe(size_t index, HANDLE completion_port, const ServerConfig& config) {
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
         std::wstring pipe_name_w = L"\\\\.\\pipe\\" + conv.from_bytes(config.pipe_name);
 
@@ -206,7 +206,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::main_loop() {
+    inline void NamedPipeServer::main_loop() {
         while (!m_is_stop_server) {
             std::unique_lock<std::mutex> lock(m_config_mutex);
             m_config_cv.wait(lock, [this] {
@@ -252,7 +252,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::run_server_loop(const ServerConfig& config) {
+    inline void NamedPipeServer::run_server_loop(const ServerConfig& config) {
         notify_start(config);
         HANDLE completion_port = m_completion_port.load(std::memory_order_acquire);
         while (!m_is_stop_server) {
@@ -349,7 +349,7 @@ namespace SimpleNamedPipe {
     }
 
     // Process all accumulated write commands
-    void NamedPipeServer::process_write_commands(size_t index) {
+    inline void NamedPipeServer::process_write_commands(size_t index) {
         std::unique_lock<std::mutex> lock(m_write_mutex);
         while (!m_pending_writes[index].empty()) {
             m_active_writes[index].push(std::move(m_pending_writes[index].front()));
@@ -363,7 +363,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::handle_write_completion(size_t index, size_t bytes_transferred) {
+    inline void NamedPipeServer::handle_write_completion(size_t index, size_t bytes_transferred) {
         if (!m_active_writes[index].empty()) {
             auto& cmd = m_active_writes[index].front();
             cmd.offset += bytes_transferred;
@@ -375,7 +375,7 @@ namespace SimpleNamedPipe {
         post_next_write(index);
     }
 
-    void NamedPipeServer::post_next_write(size_t index) {
+    inline void NamedPipeServer::post_next_write(size_t index) {
         if (m_active_writes[index].empty()) {
             m_is_writing[index] = false;
             return;
@@ -424,7 +424,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    bool NamedPipeServer::reconnect_client(size_t index, HANDLE completion_port, OVERLAPPED* ov) {
+    inline bool NamedPipeServer::reconnect_client(size_t index, HANDLE completion_port, OVERLAPPED* ov) {
         memset(ov, 0, sizeof(OVERLAPPED));
 
         BOOL connected = ConnectNamedPipe(m_pipes[index], ov);
@@ -445,7 +445,7 @@ namespace SimpleNamedPipe {
         return true;
     }
 
-    void NamedPipeServer::handle_close(size_t index, HANDLE completion_port) {
+    inline void NamedPipeServer::handle_close(size_t index, HANDLE completion_port) {
         std::unique_lock<std::mutex> lock(m_write_mutex);
         if (m_pending_closes[index].empty()) return;
         auto on_done = std::move(m_pending_closes[index].front());
@@ -467,7 +467,7 @@ namespace SimpleNamedPipe {
         if (on_done) on_done(make_error_code(NamedPipeErrc::InvalidPipeHandle));
     }
 
-    void NamedPipeServer::cleanup_pending_operations(const std::error_code& reason) {
+    inline void NamedPipeServer::cleanup_pending_operations(const std::error_code& reason) {
         std::array<std::queue<WriteCommand>, MAX_CLIENTS> pending_writes;
         std::array<std::queue<DoneCallback>, MAX_CLIENTS> pending_closes;
 
@@ -504,7 +504,7 @@ namespace SimpleNamedPipe {
         }
     }
 
-    void NamedPipeServer::notify_connected(size_t index) {
+    inline void NamedPipeServer::notify_connected(size_t index) {
         if (m_is_connected[index].load(std::memory_order_acquire)) return;
         m_is_connected[index].store(true, std::memory_order_release);
         m_connections[index] = std::make_shared<Connection>(index, this);
@@ -513,7 +513,7 @@ namespace SimpleNamedPipe {
         if (on_event) on_event(ServerEvent::client_connected(static_cast<int>(index), m_connections[index]));
     }
 
-    void NamedPipeServer::notify_disconnected(size_t index, const std::error_code& ec) {
+    inline void NamedPipeServer::notify_disconnected(size_t index, const std::error_code& ec) {
         if (!m_is_connected[index].load(std::memory_order_acquire)) return;
         m_is_connected[index].store(false, std::memory_order_release);
         if (m_connections[index]) m_connections[index]->invalidate();
@@ -522,14 +522,14 @@ namespace SimpleNamedPipe {
         if (on_event) on_event(ServerEvent::client_disconnected(static_cast<int>(index), m_connections[index], ec));
     }
 
-    void NamedPipeServer::notify_message(size_t index) {
+    inline void NamedPipeServer::notify_message(size_t index) {
         if (m_event_handler) m_event_handler->on_message(static_cast<int>(index), m_message_buffers[index]);
         if (on_message) on_message(static_cast<int>(index), m_message_buffers[index]);
         if (on_event) on_event(ServerEvent::message_received(static_cast<int>(index), m_connections[index], std::move(m_message_buffers[index])));
         m_message_buffers[index].clear();
     }
 
-    void NamedPipeServer::notify_start(const ServerConfig& config) {
+    inline void NamedPipeServer::notify_start(const ServerConfig& config) {
         if (m_is_running.load(std::memory_order_acquire)) return;
         m_is_running.store(true, std::memory_order_release);
         if (m_event_handler) m_event_handler->on_start(config);
@@ -537,7 +537,7 @@ namespace SimpleNamedPipe {
         if (on_event) on_event(ServerEvent::server_started());
     }
 
-    void NamedPipeServer::notify_stop(const ServerConfig& config) {
+    inline void NamedPipeServer::notify_stop(const ServerConfig& config) {
         if (!m_is_running.load(std::memory_order_acquire)) return;
         m_is_running.store(false, std::memory_order_release);
         if (m_event_handler) m_event_handler->on_stop(config);
@@ -545,7 +545,7 @@ namespace SimpleNamedPipe {
         if (on_event) on_event(ServerEvent::server_stopped());
     }
 
-    void NamedPipeServer::notify_error(const std::error_code& ec) {
+    inline void NamedPipeServer::notify_error(const std::error_code& ec) {
         if (m_event_handler) m_event_handler->on_error(ec);
         if (on_error) on_error(ec);
         if (on_event) on_event(ServerEvent::error_occurred(ec));

--- a/tests/odr/main1.cpp
+++ b/tests/odr/main1.cpp
@@ -1,0 +1,7 @@
+#include <SimpleNamedPipe/NamedPipeServer.hpp>
+
+int main() {
+    SimpleNamedPipe::NamedPipeServer server;
+    (void)server.is_running();
+    return 0;
+}

--- a/tests/odr/main2.cpp
+++ b/tests/odr/main2.cpp
@@ -1,0 +1,6 @@
+#include <SimpleNamedPipe/NamedPipeServer.hpp>
+
+void run_server() {
+    SimpleNamedPipe::NamedPipeServer server;
+    server.stop();
+}

--- a/tests/odr/run_odr_test.sh
+++ b/tests/odr/run_odr_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CXX="${CXX:-g++}"
+CXXFLAGS=(-std=c++17 -pthread)
+INCLUDE_FLAGS=(-I"${ROOT_DIR}/tests/stubs" -I"${ROOT_DIR}/include" -include cstring)
+
+if ! command -v "${CXX}" >/dev/null 2>&1; then
+    echo "error: C++ compiler '${CXX}' not found" >&2
+    exit 1
+fi
+
+BUILD_DIR="$(mktemp -d "odr-test-XXXXXX")"
+cleanup() {
+    rm -rf "${BUILD_DIR}"
+}
+trap cleanup EXIT
+
+compile() {
+    local source_file="$1"
+    local output_file="$2"
+    "${CXX}" "${CXXFLAGS[@]}" "${INCLUDE_FLAGS[@]}" -c "${source_file}" -o "${output_file}"
+}
+
+compile "${SCRIPT_DIR}/main1.cpp" "${BUILD_DIR}/main1.o"
+compile "${SCRIPT_DIR}/main2.cpp" "${BUILD_DIR}/main2.o"
+"${CXX}" "${CXXFLAGS[@]}" "${BUILD_DIR}/main1.o" "${BUILD_DIR}/main2.o" -o "${BUILD_DIR}/odr_test"
+
+echo "ODR test built successfully: ${BUILD_DIR}/odr_test"

--- a/tests/stubs/windows.h
+++ b/tests/stubs/windows.h
@@ -1,0 +1,120 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <cstdarg>
+
+using HANDLE = void*;
+using DWORD = std::uint32_t;
+using ULONG_PTR = std::uintptr_t;
+using BOOL = int;
+using LPVOID = void*;
+using WORD = std::uint16_t;
+using DWORD_PTR = std::uintptr_t;
+using LPDWORD = DWORD*;
+using PULONG_PTR = ULONG_PTR*;
+
+struct OVERLAPPED {
+    ULONG_PTR Internal;
+    ULONG_PTR InternalHigh;
+    union {
+        struct {
+            DWORD Offset;
+            DWORD OffsetHigh;
+        } DUMMYSTRUCTNAME;
+        LPVOID Pointer;
+    } DUMMYUNIONNAME;
+    HANDLE hEvent;
+};
+
+struct SECURITY_ATTRIBUTES {
+    DWORD nLength;
+    LPVOID lpSecurityDescriptor;
+    BOOL bInheritHandle;
+};
+
+struct FILETIME {
+    DWORD dwLowDateTime;
+    DWORD dwHighDateTime;
+};
+
+using LPOVERLAPPED = OVERLAPPED*;
+
+#define INVALID_HANDLE_VALUE reinterpret_cast<HANDLE>(-1)
+
+#define PIPE_ACCESS_DUPLEX 0x00000003
+#define FILE_FLAG_OVERLAPPED 0x40000000
+#define PIPE_TYPE_MESSAGE 0x00000004
+#define PIPE_READMODE_MESSAGE 0x00000002
+#define PIPE_WAIT 0x00000000
+#define PIPE_UNLIMITED_INSTANCES 255
+#define PIPE_REJECT_REMOTE_CLIENTS 0x00000008
+#define NMPWAIT_USE_DEFAULT_WAIT 0x00000000
+#define ERROR_IO_PENDING 997
+#define ERROR_IO_INCOMPLETE 996
+#define ERROR_PIPE_CONNECTED 535
+#define ERROR_IO_PENDING 997
+#define ERROR_PIPE_LISTENING 536
+#define ERROR_OPERATION_ABORTED 995
+#define ERROR_MORE_DATA 234
+#define ERROR_BROKEN_PIPE 109
+#define ERROR_SUCCESS 0
+#define ERROR_NO_DATA 232
+#define INFINITE 0xFFFFFFFF
+#define WAIT_TIMEOUT 258
+#define WAIT_OBJECT_0 0
+#define WAIT_FAILED 0xFFFFFFFF
+
+inline DWORD GetLastError() { return 0; }
+inline HANDLE CreateIoCompletionPort(HANDLE, HANDLE, ULONG_PTR, DWORD) { return reinterpret_cast<HANDLE>(1); }
+inline BOOL PostQueuedCompletionStatus(HANDLE, DWORD, ULONG_PTR, LPOVERLAPPED) { return 1; }
+inline HANDLE CreateNamedPipeW(const wchar_t*, DWORD, DWORD, DWORD, DWORD, DWORD, DWORD, const SECURITY_ATTRIBUTES*) { return reinterpret_cast<HANDLE>(1); }
+inline BOOL ConnectNamedPipe(HANDLE, LPOVERLAPPED) { return 1; }
+inline BOOL DisconnectNamedPipe(HANDLE) { return 1; }
+inline BOOL CloseHandle(HANDLE) { return 1; }
+inline BOOL GetQueuedCompletionStatus(HANDLE, LPDWORD, PULONG_PTR, LPOVERLAPPED*, DWORD) { return 0; }
+inline BOOL GetOverlappedResult(HANDLE, LPOVERLAPPED, LPDWORD, BOOL) { return 1; }
+inline BOOL CancelIoEx(HANDLE, LPOVERLAPPED) { return 1; }
+inline HANDLE CreateEventW(void*, BOOL, BOOL, const wchar_t*) { return reinterpret_cast<HANDLE>(1); }
+inline BOOL SetEvent(HANDLE) { return 1; }
+inline BOOL ResetEvent(HANDLE) { return 1; }
+inline DWORD WaitForSingleObject(HANDLE, DWORD) { return WAIT_OBJECT_0; }
+inline BOOL FlushFileBuffers(HANDLE) { return 1; }
+inline BOOL GetNamedPipeClientProcessId(HANDLE, ULONG_PTR*) { return 1; }
+inline BOOL GetNamedPipeClientSessionId(HANDLE, ULONG_PTR*) { return 1; }
+inline BOOL GetFileInformationByHandle(HANDLE, void*) { return 1; }
+inline BOOL ReadFile(HANDLE, void*, DWORD, LPDWORD, LPOVERLAPPED) { return 1; }
+inline BOOL WriteFile(HANDLE, const void*, DWORD, LPDWORD, LPOVERLAPPED) { return 1; }
+inline BOOL PeekNamedPipe(HANDLE, void*, DWORD, LPDWORD, LPDWORD, LPDWORD) { return 1; }
+inline DWORD FormatMessageW(DWORD, const void*, DWORD, DWORD, wchar_t*, DWORD, va_list*) { return 0; }
+inline DWORD QueueUserWorkItem(void(*)(LPVOID), LPVOID, ULONG_PTR) { return 0; }
+
+inline DWORD SleepEx(DWORD, BOOL) { return 0; }
+
+struct SYSTEM_INFO {
+    union {
+        DWORD dwOemId;
+        struct {
+            WORD wProcessorArchitecture;
+            WORD wReserved;
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+    DWORD dwPageSize;
+    LPVOID lpMinimumApplicationAddress;
+    LPVOID lpMaximumApplicationAddress;
+    DWORD_PTR dwActiveProcessorMask;
+    DWORD dwNumberOfProcessors;
+    DWORD dwProcessorType;
+    DWORD dwAllocationGranularity;
+    WORD wProcessorLevel;
+    WORD wProcessorRevision;
+};
+
+inline void GetSystemInfo(SYSTEM_INFO*) {}
+
+inline BOOL GetCommTimeouts(HANDLE, void*) { return 1; }
+inline BOOL SetCommTimeouts(HANDLE, const void*) { return 1; }
+
+inline BOOL SetNamedPipeHandleState(HANDLE, DWORD*, DWORD*, DWORD*) { return 1; }
+
+#define CALLBACK
+


### PR DESCRIPTION
## Summary
- add inline qualifiers to all NamedPipeServer member definitions in the .ipp
- allow multiple translation units to include the header without duplicate symbol errors

## Testing
- g++ -std=c++17 -Itests/stubs -Iinclude -pthread -include cstring -c tests/odr/main1.cpp -o tests/odr/main1.o
- g++ -std=c++17 -Itests/stubs -Iinclude -pthread -include cstring -c tests/odr/main2.cpp -o tests/odr/main2.o
- g++ -std=c++17 -pthread tests/odr/main1.o tests/odr/main2.o -o tests/odr/odr_test

------
https://chatgpt.com/codex/tasks/task_e_68ff400619e88328b9165c4e3e810ce2